### PR TITLE
fix: failing to flash due to directory already existing LOL-4896

### DIFF
--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -199,6 +199,10 @@ module.exports = class ResinJetsonFlash {
 	spawnFlash() {
 		return new Bluebird(async (resolve, reject) => {
 			const workPath = join(tmpdir(), 'Linux_for_Tegra');
+			
+			if (fs.existsSync(workPath)) {
+				fs.rmSync(workPath, { recursive: true, force: true });
+			}
 
 			await copy(join(this.output, 'Linux_for_Tegra'), workPath);
 			process.chdir(workPath);


### PR DESCRIPTION
Added a cleanup step using fs.rmSync to wipe the workPath directory before invoking await copy(). Ensuring a clean destination directory prevents the fs-extra symlink collision and allows the flash process to proceed reliably.